### PR TITLE
only request data when data is expected to be available

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -1,3 +1,4 @@
+#include <pebble.h>
 #include "app_keys.h"
 #include "config.h"
 #include "comm.h"
@@ -63,15 +64,17 @@ static void request_update() {
 static void in_received_handler(DictionaryIterator *received, void *context) {
   phone_contact = true;
   update_in_progress = false;
-  Tuple* recency = dict_find(received, APP_KEY_RECENCY);
-  if (recency) {
-    int32_t next_update = UPDATE_FREQUENCY - recency->value->uint32 * 1000;
-    int32_t delay = next_update < 60000 ? 60000 : next_update;
-    schedule_update((uint32_t) delay);
-  } else
-    schedule_update(UPDATE_FREQUENCY);
   staleness_update(received);
-  if (dict_find(received, APP_KEY_MSG_TYPE)->value->uint8 != MSG_TYPE_ERROR) {
+  int msg_type = dict_find(received, APP_KEY_MSG_TYPE)->value->uint8;
+  if (msg_type == MSG_TYPE_DATA) {
+    uint32_t recency = dict_find(received, APP_KEY_RECENCY)->value->uint32;
+    int32_t next_update = SGV_UPDATE_FREQUENCY - recency * 1000;
+    int32_t delay = next_update < LATE_DATA_UPDATE_FREQUENCY ? LATE_DATA_UPDATE_FREQUENCY : next_update;
+    schedule_update((uint32_t) delay);
+  }
+  if (msg_type == MSG_TYPE_ERROR) {
+    schedule_update(ERROR_RETRY_DELAY);
+  } else {
     data_callback(received);
   }
 }

--- a/src/comm.h
+++ b/src/comm.h
@@ -6,9 +6,11 @@
 
 // There are many failure modes...
 #define INITIAL_TIMEOUT 1000
-#define DEFAULT_TIMEOUT 20*1000
-#define TIMEOUT_RETRY_DELAY 10*1000
-#define OUT_RETRY_DELAY 20*1000
+#define DEFAULT_TIMEOUT (20*1000)
+#define TIMEOUT_RETRY_DELAY (10*1000)
+#define OUT_RETRY_DELAY (20*1000)
 #define IN_RETRY_DELAY 100
+#define LATE_DATA_UPDATE_FREQUENCY (60*1000)
+#define ERROR_RETRY_DELAY (60*1000)
 
 void init_comm(void (*callback)(DictionaryIterator *received));

--- a/src/config.h
+++ b/src/config.h
@@ -11,7 +11,7 @@
 // The details of the layout can be set in config.c
 #define LAYOUT LAYOUT_OPTION_A
 
-#define UPDATE_FREQUENCY ((60*1000) * 5 + 30000)
+#define SGV_UPDATE_FREQUENCY (60*1000*5 + 30*1000)
 
 // STALENESS ALERTS:
 // Show an icon if there is unacceptable lag between any component of:

--- a/src/config.h
+++ b/src/config.h
@@ -11,7 +11,7 @@
 // The details of the layout can be set in config.c
 #define LAYOUT LAYOUT_OPTION_A
 
-#define UPDATE_FREQUENCY (60*1000)
+#define UPDATE_FREQUENCY ((60*1000) * 5 + 30000)
 
 // STALENESS ALERTS:
 // Show an icon if there is unacceptable lag between any component of:


### PR DESCRIPTION
This commit causes the watch to request data 6 minutes from the most recent SGV.  If it has been more than 6 minutes since the last value it returns to a 1-minute cadence until data is avaliable.
