### PR TITLE
Support for new style nested uploader.battery field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ test/output
 *.pyc
 __pycache__
 node_modules
+.idea
+*.iml


### PR DESCRIPTION
Since we can now get battery level on the Edison using @cjo02's https://github.com/cjo20/EdisonVoltage, we uploading it the new way to prepare for additional fields.

This checks the old way first, and then falls back to the new way.
