### PR TITLE
Live-reload tool and other testing improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask==0.10.1
 pytest==2.6.1
+python-dateutil==2.5.3
 requests==2.3.0
 simplejson==3.8.0
 watchdog==0.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ flask==0.10.1
 pytest==2.6.1
 requests==2.3.0
 simplejson==3.8.0
+watchdog==0.8.3
 -e git+https://github.com/pebble/pebble-tool.git@v4.2.1#egg=pebble-tool

--- a/src/js/constants.json
+++ b/src/js/constants.json
@@ -1,6 +1,7 @@
 {
    "VERSION" : "0.0.9",
 
+   "DEBUG": false,
    "CONFIG_URL" : "https://mddub.github.io/urchin-cgm/config/",
    "LOCAL_STORAGE_KEY_CONFIG" : "config",
 

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -5,6 +5,7 @@ require('./vendor/lie.polyfill');
 
 var Cache = require('./cache');
 var debounce = require('./debounce');
+var Debug = require('./debug');
 
 var data = function(c) {
   var MAX_SGVS = c.SGV_FETCH_SECONDS / c.INTERVAL_SIZE_SECONDS + c.FETCH_EXTRA;
@@ -37,6 +38,8 @@ var data = function(c) {
   // https://github.com/bewest/share2nightscout-bridge
   var DEXCOM_APPLICATION_ID = 'd89443d2-327c-4a6f-89e5-496bbb0317db';
   var dexcomToken;
+
+  var debug = Debug(c);
 
   var d = {};
 
@@ -89,6 +92,7 @@ var data = function(c) {
 
       // On iOS, PebbleKit JS will throw an error on send() for an invalid URL
       try {
+        debug.log(method + ' ' + url);
         xhr.send(body);
         setTimeout(onTimeout, c.REQUEST_TIMEOUT);
       } catch (e) {

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -1,0 +1,13 @@
+/* global module, console */
+
+var Debug = function(c) {
+  return {
+    log: function(str) {
+      if (c.DEBUG) {
+        console.log(str);
+      }
+    }
+  };
+};
+
+module.exports = Debug;

--- a/test/do_screenshots.sh
+++ b/test/do_screenshots.sh
@@ -7,7 +7,8 @@ TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Start & background Flask server
 python "$TEST_DIR/server.py" & PID=$!
-sleep 0.5
+sleep 1
+bg
 
 # Run tests
 py.test test/ -v $@

--- a/test/live_reload.sh
+++ b/test/live_reload.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# A hacky script to make test-driven iteration much faster.
+#
+# Call with the name of a test class defined in test_screenshots.py, and it
+# will reload the emulator with its config and data on every file change.
+#
+# For other options, see: python test/set_config.py -h
+
+run () {
+  TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+  export MOCK_SERVER_PORT=5555
+  set -x
+
+  python "$TEST_DIR/server.py" --test-class "$@" & PID=$!
+  sleep 1
+  bg
+
+  python "$TEST_DIR/set_config.py" "$@"
+
+  # Requires watchdog
+  watchmedo shell-command --patterns="**/test_screenshots.py" --recursive --command="python $TEST_DIR/set_config.py $@" $TEST_DIR
+
+  kill -9 $PID
+
+  set +x
+  unset MOCK_SERVER_PORT
+}
+
+if [[ $# -eq 0 ]] ; then
+  echo 'Name of test class is required argument'
+else
+  run $@
+fi

--- a/test/server.py
+++ b/test/server.py
@@ -1,4 +1,13 @@
+"""
+Mock Nightscout server. Two modes for data source:
+1. the values received in a POST to /set-sgv, /set-treatments, etc. (default)
+2. the values defined on a screenshot test case, specified by --test-class
+"""
+
+import argparse
+import json
 import os
+import sys
 import urllib
 
 import requests
@@ -6,30 +15,54 @@ from flask import Flask, request
 from werkzeug.contrib.cache import SimpleCache
 from werkzeug.exceptions import NotFound
 
-port = int(os.environ['MOCK_SERVER_PORT'])
+import test_screenshots
+
+parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('--port')
+parser.add_argument('--test-class')
+args, _ = parser.parse_known_args()
+
+port = int(args.port or os.environ.get('MOCK_SERVER_PORT') or 0)
+if port == 0:
+    print "Port must be set via MOCK_SERVER_PORT or --port"
+    sys.exit()
 
 COLLECTIONS = ['entries', 'treatments', 'profile', 'devicestatus']
 
 cache = SimpleCache(default_timeout=999999)
-for collection in COLLECTIONS:
-    cache.set(collection, '[]')
+for coll in COLLECTIONS:
+    cache.set(coll, '[]')
 
 app = Flask(__name__)
 
 def _get_post_data(request):
     return request.data or request.form.keys()[0]
 
-@app.route('/api/v1/<collection>.json')
-def get_collection(collection):
-    if collection in COLLECTIONS:
-        return cache.get(collection)
+@app.route('/api/v1/<coll>.json')
+def get_collection(coll):
+    coll = _collection_from_test(coll, args.test_class) if args.test_class else _collection_from_cache(coll)
+    if coll is not None:
+        return coll
     else:
         raise NotFound
 
-@app.route('/set-<collection>', methods=['post'])
-def set_collection(collection):
-    if collection in COLLECTIONS:
-        cache.set(collection, _get_post_data(request))
+def _collection_from_cache(coll):
+    return cache.get(coll) if coll in COLLECTIONS else None
+
+def _collection_from_test(coll, test_class_name):
+    # XXX this is very fragile, but for now makes iterating much faster
+    reload(test_screenshots)
+    if coll == 'entries':
+        return json.dumps(getattr(test_screenshots, test_class_name)().sgvs())
+    elif coll in COLLECTIONS:
+        return []
+    else:
+        return None
+
+@app.route('/set-<coll>', methods=['post'])
+def set_collection(coll):
+    if coll in COLLECTIONS:
+        cache.set(coll, _get_post_data(request))
         return ''
     else:
         raise NotFound

--- a/test/set_config.py
+++ b/test/set_config.py
@@ -1,0 +1,24 @@
+"""
+Send the `config` dict from a test class definition to the emulator.
+Best run with `watchdog` or similar to monitor file changes.
+"""
+
+import argparse
+import os
+import sys
+
+import test_screenshots
+from util import set_config
+
+PORT = os.environ.get('MOCK_SERVER_PORT')
+
+parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('test_class', help='name of test class (e.g. TestLayoutD)')
+parser.add_argument('--platform', default='basalt', help='which emulator')
+args = parser.parse_args()
+
+config = getattr(test_screenshots, args.test_class)().config
+config['__CLEAR_CACHE__'] = True
+if PORT:
+    config['nightscout_url'] = 'http://localhost:{}'.format(PORT)
+set_config(config, [args.platform])

--- a/test/test_screenshots.py
+++ b/test/test_screenshots.py
@@ -2,6 +2,7 @@ import copy
 import math
 from datetime import datetime
 from datetime import timedelta
+from functools import partial
 
 from util import BASE_CONFIG
 from util import CONSTANTS
@@ -44,7 +45,7 @@ def default_entries(direction, count=50):
         in zip(default_sgv_series(count), default_dates(count))
     ]
 
-def some_real_life_entries():
+def some_real_life_entries(*args):
     sgvs = [190, 188, 180, 184, 184, 177, 174, 163, 152, 141, 134, 127, 124, 121, 117, 109, 103, 97, 94, 88, 79, 79, 75, 79, 84, 87, 88, 91, 91, 91, 94, 99, 102, 107, 106, 108, 107, 108, 115, 111, 114, 113, 115, 118, 120, 119, 120, 122, 123, 126, 122, 125, 125, 126, 125, 122, 122, 122, 119, 118, 118, 118, 117, 116, 115, 114, 114, 115, 114, 113, 114, 115, 111, 114, 115, 114, 114, 116, 117, 117, 118, 119, 121, 124, 125, 128, 126, 128, 131, 133, 135, 136, 135, 134, 132, 130]
     return [
         {
@@ -66,7 +67,7 @@ def mutate_element(layout, el_name, props):
 
 class TestBasicIntegration(ScreenshotTest):
     """Test that the graph, delta, trend, etc. all work."""
-    sgvs = default_entries('FortyFiveDown')
+    sgvs = partial(default_entries, 'FortyFiveDown')
 
 
 class TestMmol(ScreenshotTest):
@@ -74,7 +75,7 @@ class TestMmol(ScreenshotTest):
     config = {
         'mmol': True,
     }
-    sgvs = default_entries('Flat')
+    sgvs = partial(default_entries, 'Flat')
 
 
 class TestGraphBoundsAndGridlines(ScreenshotTest):
@@ -86,12 +87,11 @@ class TestGraphBoundsAndGridlines(ScreenshotTest):
         'bottomOfGraph': 20,
         'hGridlines': 20,
     }
-    sgvs = default_entries('DoubleUp')
+    sgvs = partial(default_entries, 'DoubleUp')
 
 
 class TestSGVsAtBoundsAndGridlines(ScreenshotTest):
     """Test that the placement of target range bounds and gridlines is consistent with the placement of SGV points."""
-    @property
     def sgvs(self):
         sgvs = default_entries('Flat')
         for i, s in enumerate(sgvs):
@@ -107,7 +107,6 @@ class TestSGVsAtBoundsAndGridlines(ScreenshotTest):
 
 class TestStaleServerData(ScreenshotTest):
     """Test that when server data is stale, an icon appears."""
-    @property
     def sgvs(self):
         return default_entries('SingleDown')[7:]
 
@@ -115,7 +114,6 @@ class TestStaleServerData(ScreenshotTest):
 class TestNotRecentButNotYetStaleSidebar(ScreenshotTest):
     """Test that trend and delta are not shown in the sidebar when data is not recent."""
     config = {'layout': 'a'}
-    @property
     def sgvs(self):
         return default_entries('SingleDown')[2:]
 
@@ -123,14 +121,12 @@ class TestNotRecentButNotYetStaleSidebar(ScreenshotTest):
 class TestNotRecentButNotYetStaleBGRow(ScreenshotTest):
     """Test that trend and delta are not shown in the BG row when data is not recent."""
     config = {'layout': 'c'}
-    @property
     def sgvs(self):
         return default_entries('SingleDown')[2:]
 
 
 class TestErrorCodes(ScreenshotTest):
     """Test that error codes appear as ??? and are not graphed."""
-    @property
     def sgvs(self):
         s = default_entries('SingleDown')
         for i in range(0, 19, 3):
@@ -142,7 +138,6 @@ class TestErrorCodes(ScreenshotTest):
 
 class TestPositiveDelta(ScreenshotTest):
     """Test that positive deltas have "+" prepended and are not treated as error codes."""
-    @property
     def sgvs(self):
         s = default_entries('SingleUp')
         s[1]['sgv'] = s[0]['sgv'] - 10
@@ -158,7 +153,6 @@ class TestTrimmingValues(ScreenshotTest):
         'bottomOfGraph': 40,
         'hGridlines': 50,
     }
-    @property
     def sgvs(self):
         s = default_entries('DoubleDown')
         for i in range(12):
@@ -172,7 +166,6 @@ class TestTrimmingValues(ScreenshotTest):
 
 class TestDegenerateEntries(ScreenshotTest):
     """Test that "bad" SGV entries don't cause the watchface to crash."""
-    @property
     def sgvs(self):
         s = default_entries('DoubleDown')
         # A raw-only entry won't have sgv, shouldn't be graphed
@@ -204,7 +197,7 @@ class TestBlackBackground(ScreenshotTest):
             'statusText': 'black as coal',
         }
 
-    sgvs = default_entries('Flat')
+    sgvs = partial(default_entries, 'Flat')
 
 
 class TestStatusTextTooLong(ScreenshotTest):
@@ -213,12 +206,12 @@ class TestStatusTextTooLong(ScreenshotTest):
         'statusContent': 'customtext',
         'statusText': '^_^ ' * 100,
     }
-    sgvs = default_entries('Flat')
+    sgvs = partial(default_entries, 'Flat')
 
 
 class TestLayoutA(ScreenshotTest):
     """Test layout A."""
-    sgvs = some_real_life_entries()
+    sgvs = some_real_life_entries
     config = {
         'layout': 'a',
         'statusContent': 'customtext',
@@ -228,7 +221,7 @@ class TestLayoutA(ScreenshotTest):
 
 class TestLayoutB(ScreenshotTest):
     """Test layout B."""
-    sgvs = some_real_life_entries()
+    sgvs = some_real_life_entries
     config = {
         'layout': 'b',
         'statusContent': 'customtext',
@@ -238,7 +231,7 @@ class TestLayoutB(ScreenshotTest):
 
 class TestLayoutC(ScreenshotTest):
     """Test layout C."""
-    sgvs = some_real_life_entries()
+    sgvs = some_real_life_entries
     config = {
         'layout': 'c',
         'statusContent': 'customtext',
@@ -248,7 +241,7 @@ class TestLayoutC(ScreenshotTest):
 
 class TestLayoutD(ScreenshotTest):
     """Test layout D."""
-    sgvs = some_real_life_entries()
+    sgvs = some_real_life_entries
     config = {
         'layout': 'd',
     }
@@ -256,7 +249,7 @@ class TestLayoutD(ScreenshotTest):
 
 class TestLayoutE(ScreenshotTest):
     """Test layout E."""
-    sgvs = some_real_life_entries()
+    sgvs = some_real_life_entries
     config = {
         'layout': 'e',
         'statusContent': 'customtext',
@@ -266,7 +259,7 @@ class TestLayoutE(ScreenshotTest):
 
 class TestLayoutCustom(ScreenshotTest):
     """Test the default custom layout."""
-    sgvs = some_real_life_entries()
+    sgvs = some_real_life_entries
     config = {
         'layout': 'custom',
         'customLayout': BASE_CONFIG['customLayout'],
@@ -295,7 +288,7 @@ class BaseBatteryLocInStatusTest(ScreenshotTest):
             'statusText': self.status_text,
         }
 
-    sgvs = default_entries('FortyFiveDown')
+    sgvs = partial(default_entries, 'FortyFiveDown')
 
 
 class TestBatteryLocInStatusAlignedWithLastLineOfText(BaseBatteryLocInStatusTest):
@@ -311,7 +304,7 @@ class TestBatteryLocInStatusMinimumPadding(BaseBatteryLocInStatusTest):
 
 
 class TestBatteryAsNumber(ScreenshotTest):
-    sgvs = default_entries('FortyFiveUp')
+    sgvs = partial(default_entries, 'FortyFiveUp')
     config = {
         'layout': 'a',
         'statusContent': 'customtext',
@@ -320,7 +313,7 @@ class TestBatteryAsNumber(ScreenshotTest):
     }
 
 class BaseDynamicTimeFontTest(ScreenshotTest):
-    sgvs = default_entries('Flat')
+    sgvs = partial(default_entries, 'Flat')
     time_height = None
 
     @property

--- a/test/util.py
+++ b/test/util.py
@@ -13,7 +13,7 @@ from libpebble2.communication.transports.websocket.protocol import WebSocketPhon
 from pebble_tool.sdk.emulator import ManagedEmulatorTransport
 
 PLATFORMS = ('aplite', 'basalt')
-PORT = os.environ['MOCK_SERVER_PORT']
+PORT = os.environ.get('MOCK_SERVER_PORT', 5555)
 MOCK_HOST = 'http://localhost:{}'.format(PORT)
 
 CONSTANTS = json.loads(

--- a/wscript
+++ b/wscript
@@ -6,6 +6,7 @@ from waflib.Task import Task
 
 DEFAULT_BUILD_ENV = 'production'
 BUILD_ENV = os.environ.get('BUILD_ENV', DEFAULT_BUILD_ENV)
+DEBUG = os.environ.get('DEBUG')
 CONSTANTS_FILE = 'src/js/constants.json'
 
 ENV_CONSTANTS_OVERRIDES = {
@@ -33,11 +34,10 @@ def ensure_dir(filename):
             raise
 
 def constants_for_environment():
-    base_constants = json.loads(open(CONSTANTS_FILE).read())
-    if BUILD_ENV in ENV_CONSTANTS_OVERRIDES.keys():
-        return dict(base_constants, **ENV_CONSTANTS_OVERRIDES[BUILD_ENV])
-    else:
-        return base_constants
+    constants = json.loads(open(CONSTANTS_FILE).read())
+    constants.update(ENV_CONSTANTS_OVERRIDES.get(BUILD_ENV, {}))
+    constants.update(DEBUG=DEBUG)
+    return constants
 
 def generate_constants_file(ctx):
     target = 'src/js/generated/constants.json'


### PR DESCRIPTION
Prelude to the next big change, whose development depended on these:
- Add a tool for live-reloading a screenshot test case in the emulator during development
- Make screenshot tests support the `treatments` and `profile` Nightscout collections
- Make timestamps/recency more consistent for screenshot tests
- Add `DEBUG` environment flag to log URLs for web requests
