### PR TITLE
Limit SGV cache by date, not count

### DIFF
--- a/test/ensure-pebble-test-environment.sh
+++ b/test/ensure-pebble-test-environment.sh
@@ -7,7 +7,11 @@ set -x
 set -e
 
 PEBBLE_TOOL_PATH=pebble-sdk-$PEBBLE_TOOL-linux64
-IMAGEMAGICK_PATH=ImageMagick-7.0.2-6
+IMAGEMAGICK_PATH=ImageMagick-7.0.3-0
+
+######## Python testing dependencies
+
+pip install -r ~/urchin-cgm/requirements.txt
 
 ######## Pebble CLI tool
 
@@ -56,7 +60,3 @@ cd ~/imagemagick/$IMAGEMAGICK_PATH
 sudo make install
 sudo ldconfig /usr/local/lib
 (convert logo: logo.gif && rm logo.gif) || { echo "ImageMagick install failed"; exit 1; }
-
-######## Python testing dependencies
-
-pip install -r ~/urchin-cgm/requirements.txt

--- a/test/js/test_cache.js
+++ b/test/js/test_cache.js
@@ -2,9 +2,10 @@
 /* globals describe, it, beforeEach */
 "use strict";
 
-var expect = require('expect.js');
+var expect = require('expect.js'),
+  timekeeper = require('timekeeper');
 
-var Cache = require('../../src/js/cache.js');
+var cache = require('../../src/js/cache.js');
 
 describe('Cache', function() {
   beforeEach(function() {
@@ -13,9 +14,9 @@ describe('Cache', function() {
 
   describe('new', function() {
     it('should use a distinct localStorage key', function() {
-      var first = new Cache('first', 10);
+      var first = new cache.WithMaxSize('first', 10);
       first.update([9, 8, 7]);
-      var second = new Cache('second', 10);
+      var second = new cache.WithMaxSize('second', 10);
       second.update([5, 4, 3]);
       expect(first.entries).to.eql([9, 8, 7]);
       expect(second.entries).to.eql([5, 4, 3]);
@@ -24,38 +25,106 @@ describe('Cache', function() {
 
   describe('update', function() {
     it('should prepend', function() {
-      var c = new Cache('foo', 10);
+      var c = new cache.WithMaxSize('foo', 10);
       c.update([1, 2]);
       c.update([3, 4]);
       expect(c.entries).to.eql([3, 4, 1, 2]);
     });
 
-    it('should truncate after maxEntries', function() {
-      var c = new Cache('foo', 6);
+    it('should truncate after maxSize', function() {
+      var c = new cache.WithMaxSize('foo', 6);
       c.update([1, 2, 3, 4]);
       c.update([5, 6, 7, 8]);
       expect(c.entries).to.eql([5, 6, 7, 8, 1, 2]);
+    });
+
+    it('should truncate after maxSecondsOld', function() {
+      var now = new Date();
+      timekeeper.freeze(now);
+      var c = new cache.WithMaxAge('bar', 10 * 60);
+      c.update([
+        {'sgv': 1, 'date': now - 3 * 60 * 1000},
+        {'sgv': 2, 'date': now - 5 * 60 * 1000},
+        {'sgv': 3, 'date': now - 10 * 60 * 1000},
+        {'sgv': 4, 'date': now - 10 * 60 * 1000 - 1},
+      ]);
+      expect(c.entries).to.eql([
+        {'sgv': 1, 'date': now - 3 * 60 * 1000},
+        {'sgv': 2, 'date': now - 5 * 60 * 1000},
+        {'sgv': 3, 'date': now - 10 * 60 * 1000},
+      ]);
     });
   });
 
   describe('revive', function() {
     it('should revive from localStorage', function() {
-       var first = new Cache('sameKey', 5);
+       var first = new cache.WithMaxSize('sameKey', 5);
        first.update([99, 88, 77]);
-       var second = new Cache('sameKey', 5);
+       var second = new cache.WithMaxSize('sameKey', 5);
        expect(second.entries).to.eql([99, 88, 77]);
     });
   });
 
   describe('clear', function() {
     it('should empty the cache, which remains empty after reviving', function() {
-       var first = new Cache('sameKey', 5);
+       var first = new cache.WithMaxSize('sameKey', 5);
        first.update([123, 456]);
        expect(first.entries).to.eql([123, 456]);
        first.clear();
        expect(first.entries).to.eql([]);
-       var second = new Cache('sameKey', 5);
+       var second = new cache.WithMaxSize('sameKey', 5);
        expect(second.entries).to.eql([]);
+    });
+  });
+
+  describe('setMaxSize', function() {
+    it('should change the cache capacity', function() {
+      var c = new cache.WithMaxSize('foo', 4);
+      c.update([1, 2, 3, 4, 5, 6]);
+      expect(c.entries).to.eql([1, 2, 3, 4]);
+      c.update([9, 8]);
+      expect(c.entries).to.eql([9, 8, 1, 2]);
+      c.setMaxSize(6);
+      c.update([11, 12, 13]);
+      expect(c.entries).to.eql([11, 12, 13, 9, 8, 1]);
+      c.setMaxSize(3);
+      c.update([-5]);
+      expect(c.entries).to.eql([-5, 11, 12]);
+    });
+  });
+
+  describe('setMaxSecondsOld', function() {
+    it('should change the cache threshold', function() {
+      var now = new Date();
+      timekeeper.freeze(now);
+      var c = new cache.WithMaxAge('bar', 10 * 60);
+      c.update([
+        {'sgv': 1, 'date': now - 3 * 60 * 1000},
+        {'sgv': 2, 'date': now - 5 * 60 * 1000},
+        {'sgv': 3, 'date': now - 10 * 60 * 1000},
+      ]);
+      expect(c.entries).to.eql([
+        {'sgv': 1, 'date': now - 3 * 60 * 1000},
+        {'sgv': 2, 'date': now - 5 * 60 * 1000},
+        {'sgv': 3, 'date': now - 10 * 60 * 1000},
+      ]);
+      c.setMaxSecondsOld(6 * 60);
+      c.update([
+        {'sgv': 0, 'date': now - 2 * 60 * 1000},
+      ]);
+      expect(c.entries).to.eql([
+        {'sgv': 0, 'date': now - 2 * 60 * 1000},
+        {'sgv': 1, 'date': now - 3 * 60 * 1000},
+        {'sgv': 2, 'date': now - 5 * 60 * 1000},
+      ]);
+      c.setMaxSecondsOld(2.5 * 60);
+      c.update([
+        {'sgv': -1, 'date': now - 1 * 60 * 1000},
+      ]);
+      expect(c.entries).to.eql([
+        {'sgv': -1, 'date': now - 1 * 60 * 1000},
+        {'sgv': 0, 'date': now - 2 * 60 * 1000},
+      ]);
     });
   });
 


### PR DESCRIPTION
For #42.

The `entries` collection can be cached based on timestamp because it has a `date` field formatted as milliseconds.  Other collections use date strings, which are not amenable to querying/comparing because different devices zone or format the date string differently. Thus they are still cached based on count instead.
