### PR TITLE
Fix wscript to rebuild JS without a `pebble clean`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build
-src/generated
 src/js/generated
 config/js/generated
 test/output

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Contributions are welcome in the form of bugs and pull requests. To report a bug
 
 * Build and run the watchface with a command like:
   ```
-  pebble clean && pebble build && pebble install --emulator basalt && pebble logs
+  pebble build && pebble install --emulator basalt && pebble logs
   ```
 
 * The watchface will ask for settings from the "phone." Open the configuration page with this command and hit "save" in your browser (you'll need to do this only once):
@@ -146,7 +146,7 @@ The most effective method of integration testing I've found is to [compare scree
 
   Build the watchface as usual:
   ```
-  pebble clean && pebble build && pebble install --emulator basalt && pebble logs
+  pebble build && pebble install --emulator basalt && pebble logs
   ```
 
   Use an editor to save mock data, send it to the server, verify it:

--- a/src/time_element.c
+++ b/src/time_element.c
@@ -3,7 +3,6 @@
 #include "preferences.h"
 #include "time_element.h"
 
-#include "generated/test_maybe.h"
 #define TESTING_TIME_DISPLAY "13:37"
 
 static BatteryComponent *create_battery_component(Layer *parent, uint8_t battery_loc) {


### PR DESCRIPTION
Properly declare dependencies to waf so that builds are much faster during development, particularly when modifying only JS.
