### PR TITLE
Add support for a fourth OpenAPS prediction line

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       "prediction2": 11,
       "prediction3": 12,
       "predictionRecency": 13,
+      "prediction4": 14,
 
       "mmol": 1,
       "topOfGraph": 2,

--- a/src/app_messages.c
+++ b/src/app_messages.c
@@ -146,6 +146,7 @@ bool validate_data_message(DictionaryIterator *data, DataMessage *out) {
   memcpy(out->prediction_1, zeroes, PREDICTION_MAX_LENGTH * sizeof(uint8_t));
   memcpy(out->prediction_2, zeroes, PREDICTION_MAX_LENGTH * sizeof(uint8_t));
   memcpy(out->prediction_3, zeroes, PREDICTION_MAX_LENGTH * sizeof(uint8_t));
+  memcpy(out->prediction_4, zeroes, PREDICTION_MAX_LENGTH * sizeof(uint8_t));
 
   bool success = true
     && get_int32(data, &out->recency, MESSAGE_KEY_recency, false, 0)
@@ -162,6 +163,7 @@ bool validate_data_message(DictionaryIterator *data, DataMessage *out) {
   get_prediction(data, out->prediction_1, MESSAGE_KEY_prediction1, &out->prediction_length);
   get_prediction(data, out->prediction_2, MESSAGE_KEY_prediction2, &out->prediction_length);
   get_prediction(data, out->prediction_3, MESSAGE_KEY_prediction3, &out->prediction_length);
+  get_prediction(data, out->prediction_4, MESSAGE_KEY_prediction4, &out->prediction_length);
   if (out->prediction_length > 0) {
     success = success && get_int32(data, &out->prediction_recency, MESSAGE_KEY_predictionRecency, false, 0);
   }

--- a/src/app_messages.h
+++ b/src/app_messages.h
@@ -31,6 +31,7 @@ typedef struct __attribute__((__packed__)) DataMessage {
   uint8_t prediction_1[PREDICTION_MAX_LENGTH];
   uint8_t prediction_2[PREDICTION_MAX_LENGTH];
   uint8_t prediction_3[PREDICTION_MAX_LENGTH];
+  uint8_t prediction_4[PREDICTION_MAX_LENGTH];
   int32_t prediction_recency;
 } DataMessage;
 

--- a/src/comm.h
+++ b/src/comm.h
@@ -3,11 +3,11 @@
 #include <pebble.h>
 #include "app_messages.h"
 
-// This can theoretically be maxed out to 984 bytes by combining:
+// This can theoretically be maxed out to 1044 bytes by combining:
 //   - status bar text of 255 characters
 //   - point width of 1px (144 points + 144 "graph extra")
-//   - 3 prediction series of length 60
-#define CONTENT_SIZE 1024
+//   - 4 prediction series of length 60
+#define CONTENT_SIZE 1200
 
 // There are many failure modes...
 #define INITIAL_TIMEOUT_HALVED 2500

--- a/src/graph_element.c
+++ b/src/graph_element.c
@@ -244,8 +244,8 @@ static void graph_update_proc(Layer *layer, GContext *ctx) {
 
   // Prediction
   if (data->prediction_length > 0 && data->received_at - data->prediction_recency >= time(NULL) - MAX_PREDICTION_AGE_TO_SHOW_SECONDS) {
-    uint8_t* series[3] = {data->prediction_1, data->prediction_2, data->prediction_3};
-    for(uint8_t si = 0; si < 3; si++) {
+    uint8_t* series[4] = {data->prediction_1, data->prediction_2, data->prediction_3, data->prediction_4};
+    for(uint8_t si = 0; si < 4; si++) {
       for(i = prediction_skip; i < data->prediction_length; i++) {
         bg = series[si][i] * 2;
         if (bg == 0) {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -84,6 +84,7 @@ function app(Pebble, c) {
           prediction1: predictions.series1,
           prediction2: predictions.series2,
           prediction3: predictions.series3,
+          prediction4: predictions.series4,
           predictionRecency: predictions.recency,
         });
       } catch (e) {

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -942,7 +942,7 @@ var data = function(c, maxSGVCount) {
           lastPredicted['predBGs']['UAM'],
           lastPredicted['predBGs']['IOB'],
           lastPredicted['predBGs']['COB'],
-          lastPredicted['predBGs']['aCOB'],
+          lastPredicted['predBGs']['ZT'] || lastPredicted['predBGs']['aCOB'],
         ].filter(function(s) {
           return s !== undefined;
         });

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -939,6 +939,7 @@ var data = function(c, maxSGVCount) {
 
       if (lastPredicted && lastPredicted['predBGs']) {
         var series = [
+          lastPredicted['predBGs']['UAM'],
           lastPredicted['predBGs']['IOB'],
           lastPredicted['predBGs']['COB'],
           lastPredicted['predBGs']['aCOB'],

--- a/src/js/format.js
+++ b/src/js/format.js
@@ -197,6 +197,7 @@ var format = function(c) {
       series1: formattedSeries[0],
       series2: formattedSeries[1],
       series3: formattedSeries[2],
+      series4: formattedSeries[3],
       recency: recency,
     };
   };


### PR DESCRIPTION
OpenAPS now generates 4 prediction lines: IOB, COB, UAM, and either aCOB or ZT.  This adds support for the fourth line.

I haven't updated any tests for this, but I have been running some form of it since March.  If you have guidance on any tests to add I am willing to make an update.