### PR TITLE
Added support for the non US Dexcom Share server

### DIFF
--- a/config/index.html
+++ b/config/index.html
@@ -67,6 +67,14 @@
               </div>
             </label>
           </div>
+          <div class="item-container">
+            <div class="item-container-content">
+              <label class="item">
+                <input name="dexcomNonUS" id="dexcomNonUS" type="checkbox" class="item-checkbox"> 
+                Use non US server
+              </label>
+            </div>
+          </div>
           <div class="item-container-footer">
             Your login information is sent only to Dexcom's servers. Otherwise it is stored only on your phone.
           </div>

--- a/config/js/config.js
+++ b/config/js/config.js
@@ -629,7 +629,8 @@
     $('#ns-url').val(current['nightscout_url'] || '');
     $('[name=dexcomUsername]').val(current['dexcomUsername'] || '');
     $('[name=dexcomPassword]').val(current['dexcomPassword'] || '');
-
+    $('[name=dexcomNonUS]').prop('checked', !!current['dexcomNonUS']);
+    
     if (current.mmol === true) {
       $('#units-mmol').addClass('active');
     } else {
@@ -692,6 +693,7 @@
       nightscout_url: $('#ns-url').val().replace(/\/$/, ''),
       dexcomUsername: $('[name=dexcomUsername]').val(),
       dexcomPassword: $('[name=dexcomPassword]').val(),
+      dexcomNonUS: $('[name=dexcomNonUS]').is(':checked'),
       hGridlines: tryParseInt($('#hGridlines').val()),
       plotLineIsCustomColor: $('[name=plotLineIsCustomColor]').val() === 'true',
       statusContent: $('#statusContent').val(),
@@ -754,6 +756,7 @@
     delete current['nightscout_url'];
     delete current['dexcomUsername'];
     delete current['dexcomPassword'];
+    delete current['dexcomNonUS'];
     delete current['statusText'];
     delete current['statusUrl'];
     delete current['statusJsonUrl'];

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -280,6 +280,7 @@ function app(Pebble, c) {
         config.nightscout_url !== oldConfig.nightscout_url ||
         config.dexcomUsername !== oldConfig.dexcomUsername ||
         config.dexcomPassword !== oldConfig.dexcomPassword ||
+        config.dexcomNonUS !== oldConfig.dexcomNonUS ||
         maxSGVs > computeMaxSGVs(oldConfig) ||
         config.__CLEAR_CACHE__
       );

--- a/src/js/constants.json
+++ b/src/js/constants.json
@@ -12,6 +12,7 @@
       "nightscout_url" : "",
       "dexcomUsername": "",
       "dexcomPassword": "",
+      "dexcomNonUS": false,
       "mmol" : false,
       "topOfGraph" : 250,
       "topOfRange" : 200,

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -28,6 +28,7 @@ var data = function(c, maxSGVCount) {
 
   // TODO this file should be split into several smaller modules
   var DEXCOM_SERVER = 'https://share1.dexcom.com';
+  var DEXCOM_SERVER_NON_US = 'https://shareous1.dexcom.com';
   var DEXCOM_LOGIN_PATH = '/ShareWebServices/Services/General/LoginPublisherAccountByName';
   var DEXCOM_LATEST_GLUCOSE_PATH = '/ShareWebServices/Services/Publisher/ReadPublisherLatestGlucoseValues';
   var DEXCOM_HEADERS = {
@@ -991,7 +992,7 @@ var data = function(c, maxSGVCount) {
       return Promise.resolve(dexcomToken);
     } else {
       return d.postJSON(
-        DEXCOM_SERVER + DEXCOM_LOGIN_PATH,
+        (config.dexcomNonUS ? DEXCOM_SERVER_NON_US : DEXCOM_SERVER) + DEXCOM_LOGIN_PATH,
         DEXCOM_HEADERS,
         {
           'applicationId': DEXCOM_APPLICATION_ID,
@@ -1022,7 +1023,7 @@ var data = function(c, maxSGVCount) {
       count = maxSGVCount;
     }
     var url = [
-      DEXCOM_SERVER,
+      config.dexcomNonUS ? DEXCOM_SERVER_NON_US : DEXCOM_SERVER,
       DEXCOM_LATEST_GLUCOSE_PATH,
       '?sessionId=' + token,
       '&minutes=' + 1440,

--- a/src/js/ga.js
+++ b/src/js/ga.js
@@ -6,6 +6,7 @@ function track(data, trackingId, watchInfo, config) {
   delete current['nightscout_url'];
   delete current['dexcomUsername'];
   delete current['dexcomPassword'];
+  delete current['dexcomNonUS'];
   delete current['statusText'];
   delete current['statusUrl'];
   delete current['statusJsonUrl'];


### PR DESCRIPTION
The non US Dexcom Share servers use a different server endpoint. I added a checkbox on the configuration and modified the data retriever to allow users to select which server should the data come from. 

I made the changes in a bit of a rush but they're relatively minimal. I'm a new user but I'm pretty sure everything's working correctly. 